### PR TITLE
concurrent-rocksdb-writes

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -100,7 +100,7 @@ impl FromStr for AddressFlow {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SumTx {
     pub is_coinbase: bool,
     pub txid: String,
@@ -158,7 +158,7 @@ impl From<Transaction> for SumTx {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IndexedTxid {
     pub index: usize,
     pub tx_id: String,
@@ -185,7 +185,7 @@ impl FromStr for IndexedTxid {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Utxo {
     pub index: usize,
     pub address: String,

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -62,7 +62,7 @@ impl RpcClient {
                     Err(e) => Err(e.to_string()),
                 }
             })
-            .buffered(32)
+            .buffered(64)
     }
 }
 


### PR DESCRIPTION
With `bitcoin.conf` on beefy machine : 
```
rpcthreads=32
rpcworkqueue=64
```
It is possible to download blocks rapidly and indexing to the rocksDB becomes the bottleneck. Writing concurrently improves the indexing time ~ 2x.